### PR TITLE
6 4 merchant coupon deactivate

### DIFF
--- a/app/controllers/coupon_status_controller.rb
+++ b/app/controllers/coupon_status_controller.rb
@@ -1,0 +1,24 @@
+class CouponStatusController < ApplicationController
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @coupon = Coupon.find(params[:id])
+    
+    if @coupon.pending_invoices?
+      flash.notice = "Error: Can't deactivate coupon with pending invoices."
+      redirect_to merchant_coupon_path
+    else
+      @coupon.update(coupon_status_params)
+      if @coupon.status == "active"
+        flash.notice = "Coupon '#{@coupon.name}' activated!"
+      else
+        flash.notice = "Coupon '#{@coupon.name}' deactivated."
+      end
+      redirect_to merchant_coupon_path
+    end
+  end
+
+  private
+  def coupon_status_params
+    params.permit(:status)
+  end
+end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -11,6 +11,7 @@ class Coupon < ApplicationRecord
   belongs_to :merchant
   has_many :invoices
   has_many :transactions, through: :invoices
+  has_many :invoice_items, through: :invoices
 
   enum discount_type: [:dollars, :percent]
   enum status: [:active, :inactive]
@@ -20,5 +21,9 @@ class Coupon < ApplicationRecord
       .joins(:transactions)
       .where("transactions.result = 1")
       .count
+  end
+
+  def pending_invoices?
+    self.invoice_items.where(status: 0).exists?
   end
 end

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -6,9 +6,12 @@
   </div>
 
 
-  <p><%= @coupon.coupon_code %></p><br/>
-
+  <p>Code: <%= @coupon.coupon_code %></p>
   <p>Discount: <%= @coupon.discount_amount %> <%= @coupon.discount_type %> off</p>
-  <p>Status: <%= @coupon.status %></p>
+  <p>Status: <%= @coupon.status.capitalize %></p>
   <p>Times Used: <%= @coupon.times_used %></p>
+  <%= button_to "Deactivate", merchant_coupon_status_path(@merchant, @coupon), method: :patch, params: {status: "inactive"} %>
+
+  <%# <strong><%= link_to "Update Item", edit_merchant_item_path(@merchant, @item) %></strong> %>
+
 </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :dashboard, only: [:index]
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
+    resources :coupon_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
     resources :coupons, only: [:index, :show, :new, :create]
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,7 +31,6 @@ FactoryBot.define do
   end
 
   factory :invoice_item do
-    status {[0,1,2].sample}
     quantity { [1,2,3,4,5].sample }
     unit_price { item.unit_price }
     status { [0,1,2].sample }

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require 'helper_methods'
 
-describe "merchant coupons show page (User Story 3)" do
+describe "merchant coupons show page (User Story 3 and 4)" do
   # As a merchant 
   # When I visit a merchant's coupon show page 
   # I see that coupon's name and code 
@@ -25,7 +25,7 @@ describe "merchant coupons show page (User Story 3)" do
     expect(page).to have_content(@coupon1.name)
     expect(page).to have_content(@coupon1.coupon_code)
     expect(page).to have_content("Discount: #{@coupon1.discount_amount} #{@coupon1.discount_type} off")
-    expect(page).to have_content(@coupon1.status)
+    expect(page).to have_content(@coupon1.status.capitalize)
     expect(page).to have_no_content(@coupon2.name)
 
     visit merchant_coupon_path(@merchant1, @coupon2)
@@ -33,7 +33,7 @@ describe "merchant coupons show page (User Story 3)" do
     expect(page).to have_content(@coupon2.name)
     expect(page).to have_content(@coupon2.coupon_code)
     expect(page).to have_content("Discount: #{@coupon2.discount_amount} #{@coupon2.discount_type} off")
-    expect(page).to have_content(@coupon2.status)
+    expect(page).to have_content(@coupon2.status.capitalize)
     expect(page).to have_no_content(@coupon3.name)
   end
 
@@ -54,5 +54,46 @@ describe "merchant coupons show page (User Story 3)" do
 
     expect(page).to have_content("Times Used: #{@coupon3.times_used}")
     expect(page).to have_no_content("Times Used: #{@coupon2.times_used}")
+  end
+
+  it "can make a button to disable items" do
+    # As a merchant 
+    # When I visit one of my active coupon's show pages
+    # I see a button to deactivate that coupon
+    # When I click that button
+    # I'm taken back to the coupon show page 
+    # And I can see that its status is now listed as 'inactive'.
+
+    # * Sad Paths to consider: 
+    # 1. A coupon cannot be deactivated if there are any pending invoices with that coupon.
+
+    visit merchant_coupon_path(@merchant1, @coupon1)
+    
+    click_button "Deactivate"
+    
+    coupon = Coupon.find(@coupon1.id)
+
+    expect(current_path).to eq(merchant_coupon_path(@merchant1, @coupon1))
+    expect(coupon.status).to eq("inactive")
+    expect(page).to have_content("Coupon '#{@coupon1.name}' deactivated.")
+  end
+
+  it "won't deactivate a coupon if coupon has pending invoices" do
+    load_test_data_us_4
+    
+    visit merchant_coupon_path(@merchant1, @coupon1)
+    
+    click_button "Deactivate"
+
+    coupon = Coupon.find(@coupon1.id)
+    expect(coupon.status).to eq("inactive")
+
+    visit merchant_coupon_path(@merchant1, @coupon2)
+    
+    click_button "Deactivate"
+
+    coupon = Coupon.find(@coupon2.id)
+    expect(coupon.status).to eq("active")
+    expect(page).to have_content("Error: Can't deactivate coupon with pending invoices.")
   end
 end

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -25,3 +25,26 @@ def load_test_data_us_3
     expect(@coupon2.times_used).to eq 1
     expect(@coupon3.times_used).to eq 0
 end
+
+def load_test_data_us_4
+    @merchant1 = Merchant.create!(name: "Hair Care")
+
+    @coupon1 = create(:coupon, coupon_code: "BOGO14", merchant_id: @merchant1.id)
+    @coupon2 = create(:coupon, coupon_code: "flarpo", merchant_id: @merchant1.id)
+
+    @invoice1 = create(:invoice, coupon_id: @coupon1.id)
+    @invoice2 = create(:invoice, coupon_id: @coupon1.id)
+    @invoice3 = create(:invoice, coupon_id: @coupon2.id)
+    @invoice4 = create(:invoice, coupon_id: @coupon2.id)
+
+    @item = create(:item, merchant_id: @merchant1.id)
+
+    @invoice_item1 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice1.id, status: 1)
+    @invoice_item2 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice1.id, status: 1)
+    @invoice_item3 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice2.id, status: 1)
+    @invoice_item4 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice2.id, status: 1)
+    @invoice_item5 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice3.id, status: 1)
+    @invoice_item6 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice3.id, status: 1)
+    @invoice_item7 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice4.id, status: 0) # Sad path: pending status prevents @coupon2 from deactivating
+    @invoice_item8 = create(:invoice_item, item_id: @item.id, invoice_id: @invoice4.id, status: 1)
+end

--- a/spec/models/coupons_spec.rb
+++ b/spec/models/coupons_spec.rb
@@ -16,6 +16,7 @@ describe Coupon do
     it { should belong_to :merchant }
     it { should have_many :invoices }
     it { should have_many(:transactions).through(:invoices) }
+    it { should have_many(:invoice_items).through(:invoices) }
   end
   
   describe "enums" do
@@ -47,6 +48,13 @@ describe Coupon do
       expect(@coupon1.times_used).to eq 4
       expect(@coupon2.times_used).to eq 1
       expect(@coupon3.times_used).to eq 0
+    end
+
+    it "pending_invoices?" do
+      load_test_data_us_4
+
+      expect(@coupon1.pending_invoices?).to eq false
+      expect(@coupon2.pending_invoices?).to eq true
     end
   end
 end


### PR DESCRIPTION
As a merchant 
When I visit one of my active coupon's show pages
I see a button to deactivate that coupon
When I click that button
I'm taken back to the coupon show page 
And I can see that its status is now listed as 'inactive'.

* Sad Paths to consider: 
1. A coupon cannot be deactivated if there are any pending invoices with that coupon.