### PR TITLE
9 7 merchant invoice show page subtotal and grand total revenues

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -14,4 +14,12 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.sum("unit_price * quantity")
   end
+
+  def discounted_revenue
+    if coupon.discount_type == "dollars"
+      total_revenue.to_f - coupon.discount_amount.to_f
+    elsif coupon.discount_type == "percent"
+      total_revenue.to_f - (total_revenue.to_f * (coupon.discount_amount.to_f / 100))
+    end
+  end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,7 +12,10 @@
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
   <p>Total Revenue: <%= @invoice.total_revenue %></p>
-
+  <% if !@invoice.coupon.nil? %>
+    <p>Grand Total Revenue: <%= @invoice.discounted_revenue %></p>
+    <p><li>Coupon Applied: <%= link_to "#{@invoice.coupon.name} (#{@invoice.coupon.coupon_code})", merchant_coupon_path(@merchant, @invoice.coupon) %></li></p>
+  <% end %>
 
   <h4>Customer:</h4>
     <%= @customer.first_name %> <%= @customer.last_name %><br>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
   end
 
   factory :coupon do
-    name {Faker::Hobby.activity}
+    name {Faker::Lorem.words}
     coupon_code {Faker::Alphanumeric.alphanumeric(number: 6, min_alpha: 3, min_numeric: 3)}
     discount_amount {Faker::Number.number(digits: 2)}
     discount_type {[0,1].sample}

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
   end
 
   factory :coupon do
-    name {Faker::Lorem.words}
+    name {Faker::Lorem.words.join(" ")}
     coupon_code {Faker::Alphanumeric.alphanumeric(number: 6, min_alpha: 3, min_numeric: 3)}
     discount_amount {Faker::Number.number(digits: 2)}
     discount_type {[0,1].sample}

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -100,4 +100,26 @@ RSpec.describe "invoices show" do
     end
   end
 
+  it "shows the discounted revenue (grand total revenue) after a coupon is applied (User Story 7)" do
+    # As a merchant
+    # When I visit one of my merchant invoice show pages
+    # I see the subtotal for my merchant from this invoice (that is, the total that does not include coupon discounts)
+    # And I see the grand total revenue after the discount was applied
+    # And I see the name and code of the coupon used as a link to that coupon's show page.
+
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+    @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+    @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+    @coupon_dollars = create(:coupon, discount_amount: 5, discount_type: 0)
+    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_dollars.id, created_at: "2012-03-27 14:54:09")
+    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
+
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    expect(page).to have_content(@invoice_1.discounted_revenue)
+    save_and_open_page
+  end
+
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -24,5 +24,37 @@ RSpec.describe Invoice, type: :model do
 
       expect(@invoice_1.total_revenue).to eq(100)
     end
+
+    describe "discounted_revenue (User Story 7)" do
+      it "subtracts dollar amount from total revenue when coupon type is dollar" do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @coupon_dollars = create(:coupon, discount_amount: 5, discount_type: 0)
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_dollars.id, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
+
+        expect(@invoice_1.total_revenue).to eq(150)
+
+        expect(@invoice_1.discounted_revenue).to eq(145)
+      end
+
+      it "subtracts percent from total revenue when coupon type is percent" do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @coupon_percent = create(:coupon, discount_amount: 5, discount_type: 1)
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_percent.id, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
+
+        expect(@invoice_1.total_revenue).to eq(150)
+
+        expect(@invoice_1.discounted_revenue).to eq(142.5)
+      end
+    end
   end
 end


### PR DESCRIPTION
As a merchant
When I visit one of my merchant invoice show pages
I see the subtotal for my merchant from this invoice (that is, the total that does not include coupon discounts)
And I see the grand total revenue after the discount was applied
And I see the name and code of the coupon used as a link to that coupon's show page.