### PR TITLE
Add user story 8: admin invoice show page (subtotal and grand total r…

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -15,11 +15,18 @@ class Invoice < ApplicationRecord
     invoice_items.sum("unit_price * quantity")
   end
 
+  def total_revenue_by_merchant_with_coupon
+    invoice_items
+      .joins(item: :merchant)
+      .where(item: {merchant: coupon.merchant})
+      .sum("invoice_items.unit_price * invoice_items.quantity")
+  end
+
   def discounted_revenue
     if coupon.discount_type == "dollars"
       total_revenue.to_f - coupon.discount_amount.to_f
     elsif coupon.discount_type == "percent"
-      total_revenue.to_f - (total_revenue.to_f * (coupon.discount_amount.to_f / 100))
+      total_revenue.to_f - (total_revenue_by_merchant_with_coupon.to_f * (coupon.discount_amount.to_f / 100))
     end
   end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -14,6 +14,10 @@
       <% end %>
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+  <% if !@invoice.coupon.nil? %>
+    <p>Grand Total Revenue: <%= @invoice.discounted_revenue %></p>
+    <p><li>Coupon Applied: <%= link_to "#{@invoice.coupon.name} (#{@invoice.coupon.coupon_code})", merchant_coupon_path(@invoice.coupon.merchant, @invoice.coupon) %></li></p>
+  <% end %>
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -69,4 +69,38 @@ describe "Admin Invoices Index Page" do
       expect(@i1.status).to eq("completed")
     end
   end
+
+  it "shows the discounted revenue (grand total revenue) after a coupon is applied (User Story 8)" do
+    # (User story 8) As an admin
+    # When I visit one of my admin invoice show pages
+    # I see the name and code of the coupon that was used (if there was a coupon applied)
+    # And I see both the subtotal revenue from that invoice (before coupon) and the grand total revenue (after coupon) for this invoice.
+
+    # Alternate Paths to consider:
+    # There may be invoices with items from more than 1 merchant. Coupons for a merchant only apply to items from that merchant.
+    # When a coupon with a dollar-off value is used with an invoice with multiple merchants' items, 
+    # the dollar-off amount applies to the total amount even though there may be items present from another merchant.
+
+    load_test_data_8
+
+    visit admin_invoice_path(@invoice_1)
+
+    expect(page).to have_content("Grand Total Revenue: #{@invoice_1.discounted_revenue}")
+  end
+
+  it "has a link to the coupon's show page on the coupon's name and coupon code" do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+    @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+    @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+    @coupon_dollars = create(:coupon, discount_amount: 5, discount_type: 0)
+    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_dollars.id, created_at: "2012-03-27 14:54:09")
+    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
+    
+    visit admin_invoice_path(@invoice_1)
+
+    expect(page).to have_link("#{@coupon_dollars.name} (#{@coupon_dollars.coupon_code})")
+    save_and_open_page
+  end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -118,8 +118,21 @@ RSpec.describe "invoices show" do
 
     visit merchant_invoice_path(@merchant1, @invoice_1)
 
-    expect(page).to have_content(@invoice_1.discounted_revenue)
-    save_and_open_page
+    expect(page).to have_content("Grand Total Revenue: #{@invoice_1.discounted_revenue}")
   end
 
+  it "has a link to the coupon's show page on the coupon's name and coupon code" do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+    @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+    @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+    @coupon_dollars = create(:coupon, discount_amount: 5, discount_type: 0)
+    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_dollars.id, created_at: "2012-03-27 14:54:09")
+    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
+    
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    expect(page).to have_link("#{@coupon_dollars.name} (#{@coupon_dollars.coupon_code})")
+  end
 end

--- a/spec/helper_methods.rb
+++ b/spec/helper_methods.rb
@@ -58,3 +58,24 @@ def load_test_data_6
     @coupon5 = create(:coupon, merchant_id: @merchant2.id)
     @coupon6 = create(:coupon, merchant_id: @merchant2.id, status: 1)
 end
+
+def load_test_data_8
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @merchant2 = Merchant.create!(name: 'Chair Care')
+
+    @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+    @item_2 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+    @item_3 = Item.create!(name: "Wood Soap", description: "This washes your chair", unit_price: 10, merchant_id: @merchant2.id, status: 1)
+    @item_4 = Item.create!(name: "Chair Clip", description: "This holds up your chair but in a clip", unit_price: 5, merchant_id: @merchant2.id)
+
+    @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+
+    @coupon_percent = create(:coupon, discount_amount: 5, discount_type: 1, merchant_id: @merchant1.id)
+
+    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_percent.id, created_at: "2012-03-27 14:54:09")
+
+    @invoice_item_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+    @invoice_item_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 6, unit_price: 10, status: 1)
+    @invoice_item_3 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 9, unit_price: 10, status: 2)
+    @invoice_item_4 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_4.id, quantity: 6, unit_price: 10, status: 1)
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -25,8 +25,14 @@ RSpec.describe Invoice, type: :model do
       expect(@invoice_1.total_revenue).to eq(100)
     end
 
-    describe "discounted_revenue (User Story 7)" do
-      it "subtracts dollar amount from total revenue when coupon type is dollar" do
+    describe "discounted_revenue (User Story 7 and 8)" do
+      # (User story 7) As a merchant
+      # When I visit one of my merchant invoice show pages
+      # I see the subtotal for my merchant from this invoice (that is, the total that does not include coupon discounts)
+      # And I see the grand total revenue after the discount was applied
+      # And I see the name and code of the coupon used as a link to that coupon's show page.
+
+      it "subtracts dollar amount from total revenue" do
         @merchant1 = Merchant.create!(name: 'Hair Care')
         @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
         @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
@@ -41,19 +47,50 @@ RSpec.describe Invoice, type: :model do
         expect(@invoice_1.discounted_revenue).to eq(145)
       end
 
-      it "subtracts percent from total revenue when coupon type is percent" do
+      it "subtracts percent only from coupon merchant's total revenue" do
+        load_test_data_8
+
+        expect(@invoice_1.total_revenue).to eq(300)
+
+        expect(@invoice_1.discounted_revenue).to eq(292.5) # Indicates that 5% discount is only applied to @merchant1's items; otherwise would be 285
+      end
+    end
+
+    describe "total_revenue_by_merchant_with_coupon (User Story 8)" do
+      # (User story 8) As an admin
+      # When I visit one of my admin invoice show pages
+      # I see the name and code of the coupon that was used (if there was a coupon applied)
+      # And I see both the subtotal revenue from that invoice (before coupon) and the grand total revenue (after coupon) for this invoice.
+
+      # Alternate Paths to consider:
+      # There may be invoices with items from more than 1 merchant. Coupons for a merchant only apply to items from that merchant.
+      # When a coupon with a dollar-off value is used with an invoice with multiple merchants' items,
+      # the dollar-off amount applies to the total amount even though there may be items present from another merchant.
+
+      it "only applies coupon to items from the coupon's merchant" do
         @merchant1 = Merchant.create!(name: 'Hair Care')
+        @merchant2 = Merchant.create!(name: 'Chair Care')
+
         @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
-        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @item_2 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @item_3 = Item.create!(name: "Wood Soap", description: "This washes your chair", unit_price: 10, merchant_id: @merchant2.id, status: 1)
+        @item_4 = Item.create!(name: "Chair Clip", description: "This holds up your chair but in a clip", unit_price: 5, merchant_id: @merchant2.id)
+
         @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
-        @coupon_percent = create(:coupon, discount_amount: 5, discount_type: 1)
+
+        @coupon_percent = create(:coupon, discount_amount: 5, discount_type: 1, merchant_id: @merchant1.id)
+
         @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, coupon_id: @coupon_percent.id, created_at: "2012-03-27 14:54:09")
-        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
-        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 6, unit_price: 10, status: 1)
 
-        expect(@invoice_1.total_revenue).to eq(150)
+        @invoice_item_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @invoice_item_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 6, unit_price: 10, status: 1)
 
-        expect(@invoice_1.discounted_revenue).to eq(142.5)
+        expect(@invoice_1.total_revenue_by_merchant_with_coupon).to eq(150)
+
+        @invoice_item_3 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 9, unit_price: 10, status: 2)
+        @invoice_item_4 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_4.id, quantity: 6, unit_price: 10, status: 1)
+
+        expect(@invoice_1.total_revenue_by_merchant_with_coupon).to eq(150) # Invoice total revenue remains 150, despite adding items to invoice from @merchant2
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -166,8 +166,8 @@ describe Merchant do
     end
 
     it "disabled_items" do 
-      expect(@merchant1.disabled_items).to eq([@item_2, @item_3, @item_4, @item_7, @item_8])
-      expect(@merchant2.disabled_items).to eq([@item_5, @item_6])
+      expect(@merchant1.disabled_items.sort).to eq([@item_2, @item_3, @item_4, @item_7, @item_8].sort)
+      expect(@merchant2.disabled_items.sort).to eq([@item_5, @item_6].sort)
     end
 
     it "five_or_more_activated_coupons?" do


### PR DESCRIPTION
…evenues)

As an admin
When I visit one of my admin invoice show pages
I see the name and code of the coupon that was used (if there was a coupon applied)
And I see both the subtotal revenue from that invoice (before coupon) and the grand total revenue (after coupon) for this invoice.

* Alternate Paths to consider: 
1. There may be invoices with items from more than 1 merchant. Coupons for a merchant only apply to items from that merchant.
2. When a coupon with a dollar-off value is used with an invoice with multiple merchants' items, the dollar-off amount applies to the total amount even though there may be items present from another merchant.